### PR TITLE
Fixed couldn't find a form on the restart page

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,6 +42,8 @@ session = HTMLSession()
 # Fetch the restart page (may end up with a login form)
 r = session.get(RESTART_URL)
 check_response(r)
+r = session.get(RESTART_URL)
+check_response(r)
 form = find_form(r)
 form_action = form.attrs['action']
 


### PR DESCRIPTION
It wasn't able to find it because it wasn't using its cookie properly (which was causing its HTML to mention not having cookies enabled and to enable them in order to be able to login). This fixes issue #1.